### PR TITLE
Added export directive to make PN532 accessible

### DIFF
--- a/lib/dart_periphery.dart
+++ b/lib/dart_periphery.dart
@@ -48,6 +48,11 @@ export 'src/i2c.dart'
 export 'src/spi.dart' show SPI, SPImode, SPIexception;
 export 'src/mmio.dart' show MMIO, MMIOexception, MMIOerrorCode;
 export 'src/hardware/utils/byte_buffer.dart' show BitOrder;
+export 'src/hardware/utils/uint.dart';
+export 'src/hardware/pn532/pn532.dart';
+export 'src/hardware/pn532/i2c_impl.dart';
+export 'src/hardware/pn532/spi_impl.dart';
+export 'src/hardware/pn532/exceptions.dart';
 export 'src/hardware/bosch.dart' show OversamplingMultiplier;
 export 'src/hardware/bme280.dart'
     show


### PR DESCRIPTION
When I made my commit for the PN532 implementation I forgot to export it. Therefore it wasn't actually usable.