### PR TITLE
fix: read full data in mifareClassicReadBlock

### DIFF
--- a/lib/src/hardware/pn532/pn532.dart
+++ b/lib/src/hardware/pn532/pn532.dart
@@ -139,7 +139,7 @@ class PN532 {
               "The first byte should be '$pn532ErrorNone' but it was '${readBlockResponse.first}'");
     }
 
-    return readBlockResponse.sublist(1, mifareBlockLength);
+    return readBlockResponse.sublist(1, mifareBlockLength + 1);
   }
 
   /// Write a block of data to the card.  Block number should be the block

--- a/lib/src/hardware/pn532/pn532.dart
+++ b/lib/src/hardware/pn532/pn532.dart
@@ -8,19 +8,16 @@ import 'package:dart_periphery/src/hardware/utils/uint.dart';
 
 typedef ListCompare = bool Function(List<dynamic>, List<dynamic>);
 
-
 class PN532 {
   final ListCompare _listCompare = const ListEquality().equals;
 
   final PN532BaseProtocol pn532ProtocolImpl;
-  
 
   /// This is the basic implementation of all the functions of the PN532.
-  /// Also the protocol unspecific communication with PN532 is implemented within 
-  /// this class. 
+  /// Also the protocol unspecific communication with PN532 is implemented within
+  /// this class.
   /// CAUTION: I only test `getFirmwareVersion()` and `readPassivTargetId()`!
   PN532({required this.pn532ProtocolImpl});
-
 
   void dispose() {
     pn532ProtocolImpl.dispose();
@@ -28,9 +25,9 @@ class PN532 {
 
   /// Checks the firmware version of the PN532 chip
   /// and returns the chip's firmware version as an int
-  int getFirmwareVersion({int timeout=pn532StandardTimeout}) {
+  int getFirmwareVersion({int timeout = pn532StandardTimeout}) {
     List<int> response = callPN532Function(
-      pn532CommandGetFirmwareVersion, 
+      pn532CommandGetFirmwareVersion,
       responseLength: 4,
       timeout: timeout,
     );
@@ -50,20 +47,18 @@ class PN532 {
 
   /// Before you read MiFare-Cards you should call the `setSamConfiguration`
   /// function to configure the PN532 properly!
-  List<int> getPassivTargetId({int cardBaudrate=pn532MifareIso14443A, int timeout=pn532StandardTimeout}) {
+  List<int> getPassivTargetId(
+      {int cardBaudrate = pn532MifareIso14443A,
+      int timeout = pn532StandardTimeout}) {
     // Send passive read command for 1 card.  Expect at most a 7 byte UUID.
     List<int> parameters = [0x01, cardBaudrate];
-    List<int> response = callPN532Function(
-      pn532CommandInListPassiveTarget, 
-      parameters: parameters,
-      responseLength: 19, 
-      timeout: timeout
-    );
+    List<int> response = callPN532Function(pn532CommandInListPassiveTarget,
+        parameters: parameters, responseLength: 19, timeout: timeout);
 
     // Check only 1 card with up to a 7 byte UID is present.
     final int numberOfTagsFound = response[0];
     if (numberOfTagsFound != 1) {
-        throw PN532MoreThenOneTagsFoundException();
+      throw PN532MoreThenOneTagsFoundException();
     }
 
     final int lengthOfUid = response[5];
@@ -85,74 +80,73 @@ class PN532 {
   void setSamConfiguration({int mode = 1, int timeout = 20, int irqPin = 1}) {
     // Note that no other verification is necessary as call_function will
     // check the command was executed as expected.
-    List<int> parameters = [Uint8(mode).value, Uint8(timeout).value, Uint8(irqPin).value];
+    List<int> parameters = [
+      Uint8(mode).value,
+      Uint8(timeout).value,
+      Uint8(irqPin).value
+    ];
     callPN532Function(pn532CommandSamConfiguration, parameters: parameters);
   }
-
 
   /// Authenticate specified block number for a MiFare classic card.
   /// uid: A byte array with the UID of the card.
   /// block_number: The block to authenticate.
   /// key_number: The key type (like MIFARE_CMD_AUTH_A or MIFARE_CMD_AUTH_B).
   ///  A byte array with the key data.
-  void mifareClassicAuthenticateBlock(List<Uint8> uid, Uint8 blockNumber, Uint8 keyNumber, List<Uint8> key) {
+  void mifareClassicAuthenticateBlock(
+      List<Uint8> uid, Uint8 blockNumber, Uint8 keyNumber, List<Uint8> key) {
     // Build parameters for InDataExchange command to authenticate MiFare card.
-    List<int> parameters = List.generate(3 + mifareKeyLength + uid.length, (_) => 0);
+    List<int> parameters =
+        List.generate(3 + mifareKeyLength + uid.length, (_) => 0);
     parameters[0] = 0x01;
     parameters[1] = keyNumber.value;
     parameters[2] = blockNumber.value;
 
     // params[3:3+keylen] = key
     for (int i = 0; i < mifareKeyLength; i++) {
-        parameters[3 + i] = key[i].value;
+      parameters[3 + i] = key[i].value;
     }
     // params[3+keylen:] = uid
     for (int i = 0; i < uid.length; i++) {
-        parameters[3 + mifareKeyLength + i] = uid[i].value;
+      parameters[3 + mifareKeyLength + i] = uid[i].value;
     }
 
-    List<int> response = callPN532Function(
-      pn532CommandInDataExchange,
-      parameters: parameters,
-      responseLength: 1
-    );
+    List<int> response = callPN532Function(pn532CommandInDataExchange,
+        parameters: parameters, responseLength: 1);
 
     if (response.first != pn532ErrorNone) {
       throw PN532BadResponseException(
-        response: response,
-        additionalInformation: "The first byte should be '$pn532ErrorNone' but it was '${response.first}'"
-      );
+          response: response,
+          additionalInformation:
+              "The first byte should be '$pn532ErrorNone' but it was '${response.first}'");
     }
   }
-
 
   /// Read a block of data from the card. Block number should be the block to read.
   List<int> mifareClassicReadBlock(Uint8 blockNumber) {
     final List<int> parameters = [0x01, mifareCmdRead, blockNumber.value];
 
     final List<int> readBlockResponse = callPN532Function(
-      pn532CommandInDataExchange, 
-      parameters: parameters, 
-      responseLength: mifareBlockLength + 1
-    );
-      
+        pn532CommandInDataExchange,
+        parameters: parameters,
+        responseLength: mifareBlockLength + 1);
+
     // Check first response is 0x00 to show success.
     if (readBlockResponse.first != pn532ErrorNone) {
       throw PN532BadResponseException(
-        response: readBlockResponse,
-        additionalInformation: "The first byte should be '$pn532ErrorNone' but it was '${readBlockResponse.first}'"
-      );
+          response: readBlockResponse,
+          additionalInformation:
+              "The first byte should be '$pn532ErrorNone' but it was '${readBlockResponse.first}'");
     }
 
     return readBlockResponse.sublist(1, mifareBlockLength);
   }
 
-
   /// Write a block of data to the card.  Block number should be the block
   /// to write and data should be a byte array of length 16 with the data to write.
   void mifareClassicWriteBlock(Uint8 blockNumber, List<int> data) {
     List<int> parameters = List.generate(mifareBlockLength + 3, (index) => 0);
-    
+
     parameters[0] = 0x01; // Max card numbers
     parameters[1] = mifareCmdWrite;
     parameters[2] = blockNumber.value;
@@ -161,20 +155,16 @@ class PN532 {
       parameters[3 + i] = data[i];
     }
 
-    final List<int> responseCode = callPN532Function(
-      pn532CommandInDataExchange,
-      parameters: parameters,
-      responseLength: 1
-    );
+    final List<int> responseCode = callPN532Function(pn532CommandInDataExchange,
+        parameters: parameters, responseLength: 1);
 
     if (responseCode.first != pn532ErrorNone) {
       throw PN532BadResponseException(
-        response: responseCode,
-        additionalInformation: "The first byte should be '$pn532ErrorNone' but it was '${responseCode.first}'"
-      );
+          response: responseCode,
+          additionalInformation:
+              "The first byte should be '$pn532ErrorNone' but it was '${responseCode.first}'");
     }
   }
-
 
   /// Read a block of data from the card. Block number should be the block
   /// to read.
@@ -182,7 +172,7 @@ class PN532 {
   List<int> ntag2xxReadBlock(Uint8 blockNumber) {
     final List<int> parameters = [0x01, mifareCmdRead, blockNumber.value];
 
-    // The response length of NTAG2xx is same as Mifare's 
+    // The response length of NTAG2xx is same as Mifare's
     // Send InDataExchange request to read block of MiFare data.
     final List<int> readBlockResponse = callPN532Function(
       pn532CommandInDataExchange,
@@ -193,9 +183,9 @@ class PN532 {
     // Check first response is 0x00 to show success.
     if (readBlockResponse.first != pn532ErrorNone) {
       throw PN532BadResponseException(
-        response: readBlockResponse,
-        additionalInformation: "The first byte should be '$pn532ErrorNone' but it was '${readBlockResponse.first}'"
-      );
+          response: readBlockResponse,
+          additionalInformation:
+              "The first byte should be '$pn532ErrorNone' but it was '${readBlockResponse.first}'");
     }
 
     // Although the response length of NTAG2xx is same as Mifare's,
@@ -203,45 +193,44 @@ class PN532 {
     return readBlockResponse.sublist(1, ntag2XxBlockLength);
   }
 
-
   /// Write a block of data to the card.  Block number should be the block
   /// to write and data should be a byte array of length 4 with the data to
   /// write.
   void ntag2xxWriteBlock(Uint8 blockNumber, List<int> data) {
-    final List<int> parameters = List.generate(ntag2XxBlockLength + 3, (index) => 0);
+    final List<int> parameters =
+        List.generate(ntag2XxBlockLength + 3, (index) => 0);
     parameters[0] = 0x01; // Max card numbers
     parameters[1] = mifareUltralightCmdWrite;
     parameters[2] = blockNumber.value;
 
     for (int i = 0; i < ntag2XxBlockLength; i++) {
-        parameters[3 + i] = data[i];
+      parameters[3 + i] = data[i];
     }
 
-    final List<int> responseCode = callPN532Function(
-      pn532CommandInDataExchange,
-      parameters: parameters,
-      responseLength: 1
-    );
+    final List<int> responseCode = callPN532Function(pn532CommandInDataExchange,
+        parameters: parameters, responseLength: 1);
 
     if (responseCode.first != pn532ErrorNone) {
       throw PN532BadResponseException(
-        response: responseCode,
-        additionalInformation: "The first byte should be '$pn532ErrorNone' but it was '${responseCode.first}'"
-      );
+          response: responseCode,
+          additionalInformation:
+              "The first byte should be '$pn532ErrorNone' but it was '${responseCode.first}'");
     }
   }
 
-
-  /// Send the `command` and given `parameters` to the PN532 
+  /// Send the `command` and given `parameters` to the PN532
   /// and only wait `timeout` ms for the PN532  to say it's ready.
-  /// 
+  ///
   /// Also a `responseLength` can be given which reads the length from the PN532
   /// and return the response as an `List<int>`
-  /// 
+  ///
   /// Can throw todo
-  List<int> callPN532Function(int command, {List<int> parameters=const [], int responseLength=0, int timeout=pn532StandardTimeout}) {
+  List<int> callPN532Function(int command,
+      {List<int> parameters = const [],
+      int responseLength = 0,
+      int timeout = pn532StandardTimeout}) {
     final List<int> commandList = [pn532HostToPn532, command, ...parameters];
-    
+
     // write the command to the board
     try {
       writeCommand(commandList);
@@ -249,7 +238,7 @@ class PN532 {
       pn532ProtocolImpl.wakeUp();
       rethrow;
     }
-    
+
     // Wait for chip to say its ready!
     pn532ProtocolImpl.waitReady(timeout: timeout);
 
@@ -259,7 +248,7 @@ class PN532 {
     // wait for a response or return if no response is excpected
     if (responseLength == 0) {
       return [];
-    } 
+    }
 
     // wait for the response
     pn532ProtocolImpl.waitReady(timeout: timeout);
@@ -270,36 +259,31 @@ class PN532 {
     if (response[0] != pn532Pn532ToHost) {
       throw PN532NotToHostResponse();
     } else if (response[1] != command + 1) {
-      throw PN532WrongResponseException(
-        command: command,
-        response: response
-      );
+      throw PN532WrongResponseException(command: command, response: response);
     }
 
     // return the response without the pre verification bytes
     return response.sublist(2);
   }
 
-
   /// Read the Ack flag of the PN532
-  /// Can throw `PN532WrongAckException` when the read 
+  /// Can throw `PN532WrongAckException` when the read
   /// Ack flag was not `pn532Ack`
   void _readAck() {
     const int ackBuffLen = 6;
     final List<int> response = pn532ProtocolImpl.readData(ackBuffLen);
-    
+
     if (!_listCompare(response, pn532Ack)) {
       throw PN532WrongAckException(ackResponse: response);
     }
   }
-
 
   void writeCommand(List<int> commands) {
     Uint8 commandLength = Uint8(commands.length);
     List<int> finalCommandsList = [];
     Uint8 checksum = Uint8.zero();
 
-    // Adding all the neccessary padding commands and add some of them to the 
+    // Adding all the neccessary padding commands and add some of them to the
     // checksum (I actually don't really know why some of same aren't taken
     // into account when we calculate the checksum)
     finalCommandsList.add(pn532Preamble);
@@ -312,9 +296,9 @@ class PN532 {
     finalCommandsList.add(commandLength.value);
     finalCommandsList.add((~commandLength + Uint8(1)).value);
 
-    // adding the actual commands to the final list 
+    // adding the actual commands to the final list
     //and calculate checksum with it
-    for (int command in commands) { 
+    for (int command in commands) {
       finalCommandsList.add(command);
       checksum += Uint8(command);
     }
@@ -326,21 +310,19 @@ class PN532 {
     pn532ProtocolImpl.writeData(finalCommandsList);
   }
 
-
   List<int> readResponse(int length) {
     // Read a data frame with the expected data length
     final List<int> rawResponse = pn532ProtocolImpl.readData(length + 7);
 
     // remove trailing 0x00 bytes before the 0xff
     int offset;
-    
+
     try {
       offset = rawResponse.indexOf(0xff);
     } on StateError {
       throw PN532BadResponseException(
-        response: rawResponse,
-        additionalInformation: "Preamble doesn't contain 0xff."
-      );
+          response: rawResponse,
+          additionalInformation: "Preamble doesn't contain 0xff.");
     }
 
     // step on index after the preamble
@@ -348,32 +330,31 @@ class PN532 {
 
     if (offset >= rawResponse.length) {
       throw PN532BadResponseException(
-        response: rawResponse,
-        additionalInformation: "Response doesn't contain any data"
-      );
+          response: rawResponse,
+          additionalInformation: "Response doesn't contain any data");
     }
 
     // frame length (response[offset]) and length checksum should match
     final int frameLength = rawResponse[offset];
     if (Uint8(frameLength + rawResponse[offset + 1]).value != 0) {
       throw PN532BadResponseException(
-        response: rawResponse,
-        additionalInformation: "The frame length and frame length checksum don't macht."
-      );
+          response: rawResponse,
+          additionalInformation:
+              "The frame length and frame length checksum don't macht.");
     }
 
     // new offset without the length and length checksum
     offset += 2;
 
     // get actual response data and check the checksum of it
-    final List<int> response = rawResponse.sublist(offset, offset + frameLength + 1);
+    final List<int> response =
+        rawResponse.sublist(offset, offset + frameLength + 1);
 
     Uint8 checksum = Uint8(response.reduce((el1, el2) => el1 + el2));
     if (checksum != Uint8.zero()) {
       throw PN532BadResponseException(
-        response: response,
-        additionalInformation: "Calculated checksum doesn't match checksum."
-      );
+          response: response,
+          additionalInformation: "Calculated checksum doesn't match checksum.");
     }
 
     return response;


### PR DESCRIPTION
This PR contains 2 commits. 

- The first one is just reformatting the file using default `dartfmt`.
- The second one is the actual fix: `mifareBlockLength` is the length of the data block. Since response contains error flag in the first byte, we start reading from the `2nd` element of the list, so we need to pass `mifareBlockLength + 1` as the `end` parameter to the sublist (the end is exclusive).